### PR TITLE
Featrue/#2 implement navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,21 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:tulovnori/screens/screen_index.dart';
+import 'package:tulovnori/screens/screen_nori.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(TulovnoriApp());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
+class TulovnoriApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      debugShowCheckedModeBanner: false,
       title: 'TULOVNORI',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const Scaffold(),
+      initialRoute: '/index',
+      routes: {
+        '/index': (context) => ScreenIndex(),
+        '/nori': (context) => ScreenNori(),
+      },
     );
   }
 }

--- a/lib/screens/screen_index.dart
+++ b/lib/screens/screen_index.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class ScreenIndex extends StatefulWidget {
+  const ScreenIndex({super.key});
+
+  @override
+  State<ScreenIndex> createState() => _ScreenIndexState();
+}
+
+class _ScreenIndexState extends State<ScreenIndex> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Index'),
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Center(
+            child: ElevatedButton(
+              child: Text('NORI'),
+              onPressed: () async {
+                await Navigator.pushNamed(context, '/nori');
+              },
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/screen_nori.dart
+++ b/lib/screens/screen_nori.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+class ScreenNori extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/screens/screen_nori.dart
+++ b/lib/screens/screen_nori.dart
@@ -1,8 +1,19 @@
 import 'package:flutter/material.dart';
 
-class ScreenNori extends StatelessWidget {
+class ScreenNori extends StatefulWidget {
+  const ScreenNori({super.key});
+
+  @override
+  State<ScreenNori> createState() => _NoriState();
+}
+
+class _NoriState extends State<ScreenNori> {
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('NORI'),
+      ),
+    );
   }
 }

--- a/lib/screens/scrren_index.dart
+++ b/lib/screens/scrren_index.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+class ScreenIndex extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/screens/scrren_index.dart
+++ b/lib/screens/scrren_index.dart
@@ -1,8 +1,0 @@
-import 'package:flutter/material.dart';
-
-class ScreenIndex extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return const Placeholder();
-  }
-}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,89 +1,25 @@
 name: tulovnori
 description: "TULOVNORI - frontend flutter project"
-# The following line prevents the package from being accidentally published to
-# pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-# In Windows, build-name is used as the major, minor, and patch parts
-# of the product and file versions while build-number is used as the build suffix.
+publish_to: 'none'
 version: 1.0.0+1
 
 environment:
   sdk: ^3.6.1
 
-# Dependencies specify other packages that your package needs in order to work.
-# To automatically upgrade your package dependencies to the latest versions
-# consider running `flutter pub upgrade --major-versions`. Alternatively,
-# dependencies can be manually updated by changing the version numbers below to
-# the latest version available on pub.dev. To see which dependencies have newer
-# versions available, run `flutter pub outdated`.
 dependencies:
   flutter:
     sdk: flutter
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  # The "flutter_lints" package below contains a set of recommended lints to
-  # encourage good coding practices. The lint set provided by the package is
-  # activated in the `analysis_options.yaml` file located at the root of your
-  # package. See that file for information about deactivating specific lint
-  # rules and activating additional ones.
   flutter_lints: ^5.0.0
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
 
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
   # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/to/resolution-aware-images
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/to/asset-from-package
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/to/font-from-package
+  #   - images/

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:tulovnori/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(TulovnoriApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
본 PR은 Navigation 설정에 대한 내용을 담고 있다.

변경내용 : 
- Navigation에 사용할 Screen 파일들을 screens 패키지내에 생성하였다. (screen_index.dart, screen_nori.dart)
- main.dart에서 named navigation 방식을 위한 routes 속성을 설정하였다.
- screen_index.dart에서 screen_nori.dart로 이동하는 버튼을 작성해 두었다.

확인 : 
- [X] screen_index.dart에 구현한 버튼을 이용해 문제없이 screen_nori.dart로 이동하는 것을 확인하였다.

이후 계획 : 
-  index에서 전달된 데이터를 기반으로 nori 페이지가 구현되도록 screen_nori.dart을 수정할 것이다.
- 구현된 도구들의 버튼이 index 스크린에서 동적으로 생성되도록 수정할 것이다.
- screen_nori.dart에서 해당 기능을 수행할 도구 페이지로 이동하도록 navigation을 구축하고, 도구 페이지도 생성할 것이다.